### PR TITLE
Add CSS Standard Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# postcss-selector-not [![Build Status](https://travis-ci.org/postcss/postcss-selector-not.svg?branch=master)](https://travis-ci.org/postcss/postcss-selector-not)
+# postcss-selector-not [![CSS Standard Status](https://jonathantneal.github.io/css-db/badge/selectors-negation.svg)](https://jonathantneal.github.io/css-db/#selectors-negation) [![Build Status](https://travis-ci.org/postcss/postcss-selector-not.svg?branch=master)](https://travis-ci.org/postcss/postcss-selector-not)
 
 > PostCSS plugin to transform `:not()` W3C CSS leve 4 pseudo class to :not() CSS level 3 selectors
 


### PR DESCRIPTION
Hey there. I’m just trying to get the word out that cssdb has badges to help users know the status of your CSS polyfill.

[cssdb](https://jonathantneal.github.io/css-db/) is a list I’m compiling of CSS features and their positions in the process of becoming implemented web standards.