### PR TITLE
Add edge case about attribute selector containing :not

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,11 @@ function explodeSelector(pseudoClass, selector) {
   if (selector && position > -1) {
     const pre = selector.slice(0, position)
     const matches = balancedMatch("(", ")", selector.slice(position))
+
+    if (!matches) {
+      return selector
+    }
+
     const bodySelectors = matches.body
       ? list
         .comma(matches.body)

--- a/test/index.js
+++ b/test/index.js
@@ -21,6 +21,30 @@ tape("postcss-selector-not", t => {
   )
 
   t.equal(
+    transform("em[attr=:not] {}"),
+    "em[attr=:not] {}",
+    "should do nothing if an attribute selector value contains :not"
+  )
+
+  t.equal(
+    transform("em[attr~=:not] {}"),
+    "em[attr~=:not] {}",
+    "should really do nothing if an attribute selector value contains :not"
+  )
+
+  t.equal(
+    transform("em[:not=abc] {}"),
+    "em[:not=abc] {}",
+    "should do nothing if a selector on an attribute named :not"
+  )
+
+  t.equal(
+    transform(":not {}"),
+    ":not {}",
+    "should do nothing if :not has missing parenthesis"
+  )
+
+  t.equal(
     transform(":not(a, b) {}"),
     ":not(a):not(b) {}",
     "should transform simple :not()"
@@ -29,7 +53,7 @@ tape("postcss-selector-not", t => {
   t.equal(
     transform("tag:not(.class, .class2) {}"),
     "tag:not(.class):not(.class2) {}",
-    "should transform directes :not()"
+    "should transform into multiple :not()"
   )
 
   t.equal(


### PR DESCRIPTION
I stumbled upon an edge case about an attribute selector containing `:not` which is a valid selector. For instance, I have the following selector for displaying a bank note emoji :

```css
em[data-emoji=":notes:"]:before,
em[data-emoji="notes"]:before {
  background-image: url("https://twemoji.maxcdn.com/v/latest/svg/1f3b6.svg");
}
```

As you can see, the attribute selector contains `:notes:` which obviously contains `:not`. 

When that happens, the returned value of the `balancedMatch` will return false because there are no parenthesis. As a result, we will encounter a `Cannot read property 'body' of undefined` during compilation:

```log
Module build failed (from ./node_modules/@nuxt/webpack/node_modules/postcss-loader/src/index.js):
TypeError: Cannot read property 'body' of undefined

...
...
at explodeSelector (/var/www/html/node_modules/postcss-selector-not/dist/index.js:26:33)
at /var/www/html/node_modules/postcss-selector-not/dist/index.js:62:27
...
...

```