### PR TITLE
Fix export

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,5 +7,6 @@
     }]
   ],
   "plugins": [
+    "add-module-exports"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@babel/cli": "^7.11.6",
     "@babel/preset-env": "^7.11.5",
     "@babel/register": "^7.11.5",
+    "babel-plugin-add-module-exports": "^1.0.4",
     "eslint": "^7.9.0",
     "postcss": "^8.1.0",
     "tape": "^5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,6 +993,11 @@ available-typed-arrays@^1.0.0, available-typed-arrays@^1.0.2:
   dependencies:
     array-filter "^1.0.0"
 
+babel-plugin-add-module-exports@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-1.0.4.tgz#6caa4ddbe1f578c6a5264d4d3e6c8a2720a7ca2b"
+  integrity sha512-g+8yxHUZ60RcyaUpfNzy56OtWW+x9cyEe9j+CranqLiqbju2yf/Cy6ZtYK40EZxtrdHllzlVZgLmcOUCTlJ7Jg==
+
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz#84fda19c976ec5c6defef57f9427b3def66e17a3"


### PR DESCRIPTION
Fixes `Error: [object Object] is not a PostCSS plugin`.

This is similar to #8. The plugin is exported as `module.exports.default`, while `module.exports` is needed.

---

The full console output:

```
/Users/valtteri/Desktop/postcss-selector-not-test/node_modules/postcss/lib/processor.js:60
        throw new Error(i + ' is not a PostCSS plugin')
        ^

Error: [object Object] is not a PostCSS plugin
    at Processor.normalize (/Users/valtteri/Desktop/postcss-selector-not-test/node_modules/postcss/lib/processor.js:60:15)
    at new Processor (/Users/valtteri/Desktop/postcss-selector-not-test/node_modules/postcss/lib/processor.js:9:25)
    at postcss (/Users/valtteri/Desktop/postcss-selector-not-test/node_modules/postcss/lib/postcss.js:25:10)
    at Object.<anonymous> (/Users/valtteri/Desktop/postcss-selector-not-test/index.js:6:1)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
    at internal/main/run_main_module.js:17:47
```

The testing code:

```js
const postcss = require('postcss');
const plugin = require('postcss-selector-not');

const css = ':not(.foo, .bar) { color: red; }';

postcss([plugin])
   .process(css)
   .then(result => console.log(result.css));
```